### PR TITLE
Feature/10 fix virtual list height

### DIFF
--- a/src/components/layout/MyPageLayout.tsx
+++ b/src/components/layout/MyPageLayout.tsx
@@ -11,7 +11,7 @@ export default function MyPageLayout() {
     <div className="flex flex-col items-center justify-start gap-8 p-8 md:flex-row md:items-start md:justify-center">
       {width < MD_WIDTH_PIXEL ? <MobileMyPageNavBar /> : <MyPageSideBar />}
 
-      <div className="min-h-[700px] max-w-4xl flex-1 rounded-lg border border-gray-200 bg-white p-8">
+      <div className="flex min-h-[700px] flex-1 flex-col rounded-lg border border-gray-200 bg-white p-8">
         <Outlet />
       </div>
     </div>

--- a/src/components/my-page/bookmarked-pages/BookmarkedContent.tsx
+++ b/src/components/my-page/bookmarked-pages/BookmarkedContent.tsx
@@ -3,10 +3,9 @@ import { Input } from '@/components/common/input'
 import EmptyResultState from '@/components/common/state/EmptyResultState'
 import { BookmarkedRecruitmentCard } from '@/components/my-page'
 import BookmarkedLectureCard from '@/components/my-page/bookmarked-lecture/BookmarkedLectureCard'
-import { useWindowHeight, useWindowWidth } from '@/hooks'
+import { useWindowWidth } from '@/hooks'
 import type { BookmarkedLectures } from '@/types/api-response-types/lecture-response-type'
 import type { BookmarkedRecruitments } from '@/types/api-response-types/recruitment-response-types'
-import { cn } from '@/utils'
 import type {
   InfiniteData,
   UseInfiniteQueryResult,
@@ -22,7 +21,6 @@ const LECTURE = '강의'
 
 const ESTIMATE_CARD_SIZE_PX = 260
 const OVER_SCAN = 3
-const FOOTER_SPACE = 1000 //완벽히 footer 사이즈에 맞춘게 아니고 적당히 보이게 설정
 
 type optionKey = 'entire' | 'lecture' | 'recruitment'
 type optionValue = typeof ENTIRE | typeof RECRUITMENT | typeof LECTURE
@@ -154,7 +152,6 @@ export default function BookmarkedContent({
     virtualizer.getVirtualItems(),
   ])
 
-  const windowHeight = useWindowHeight()
   const windowWidth = useWindowWidth()
 
   const items = virtualizer.getVirtualItems()
@@ -211,8 +208,8 @@ export default function BookmarkedContent({
     selectedOption.startsWith(ENTIRE) || selectedOption.startsWith(LECTURE)
 
   return (
-    <div>
-      <header className="mb-6 flex w-full flex-col items-center justify-between gap-2 lg:flex-row">
+    <div className="flex h-full flex-col">
+      <header className="mb-6 flex w-full flex-shrink-0 flex-col items-center justify-between gap-2 lg:flex-row">
         <div className="w-full flex-col items-start justify-center gap-2">
           <h1 className="text-heading5 text-gray-900">북마크한 공고</h1>
           <span className="text-sm text-gray-600">
@@ -242,18 +239,15 @@ export default function BookmarkedContent({
         </div>
       </header>
       <main
-        className="overflow-y-auto"
+        className="flex-1 overflow-y-auto"
         ref={parentRef}
         style={{
-          height: `${windowHeight - FOOTER_SPACE}px`,
           width: `${(windowWidth * 7) / 10}px`,
         }}
       >
         <div
-          className={cn(
-            `h-[${virtualizer.getTotalSize()}px]`,
-            'relative w-full'
-          )}
+          className="relative w-full"
+          style={{ height: `${virtualizer.getTotalSize()}px` }}
         >
           <div
             style={{

--- a/src/components/my-page/bookmarked-pages/BookmarkedContent.tsx
+++ b/src/components/my-page/bookmarked-pages/BookmarkedContent.tsx
@@ -3,7 +3,7 @@ import { Input } from '@/components/common/input'
 import EmptyResultState from '@/components/common/state/EmptyResultState'
 import { BookmarkedRecruitmentCard } from '@/components/my-page'
 import BookmarkedLectureCard from '@/components/my-page/bookmarked-lecture/BookmarkedLectureCard'
-import { useWindowWidth } from '@/hooks'
+import { useWindowWidth, useObserver } from '@/hooks'
 import type { BookmarkedLectures } from '@/types/api-response-types/lecture-response-type'
 import type { BookmarkedRecruitments } from '@/types/api-response-types/recruitment-response-types'
 import type {
@@ -12,7 +12,7 @@ import type {
 } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { SearchIcon } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 const ENTIRE = '전체'
@@ -108,6 +108,29 @@ export default function BookmarkedContent({
 
   //버추얼리스트 스크롤 대상
   const parentRef = useRef<HTMLDivElement>(null)
+
+  const handleIntersect = useCallback(() => {
+    if (hasNextRecruitment && !isFetchingNextRecruitments) {
+      fetchNextRecruitments()
+    }
+    if (hasNextLecture && !isFetchingNextLectures) {
+      fetchNextLectures()
+    }
+  }, [
+    hasNextRecruitment,
+    hasNextLecture,
+    isFetchingNextRecruitments,
+    isFetchingNextLectures,
+    fetchNextRecruitments,
+    fetchNextLectures,
+  ])
+
+  // 무한 스크롤 옵저버 센서 부착용 훅
+  const observerRef = useObserver(handleIntersect, {
+    threshold: 0,
+    root: parentRef.current,
+  })
+
   //가상화 인스턴스
   const virtualizer = useVirtualizer({
     count: contents.length + additionalVirtualItemCount,
@@ -115,42 +138,6 @@ export default function BookmarkedContent({
     estimateSize: () => ESTIMATE_CARD_SIZE_PX,
     overscan: OVER_SCAN,
   })
-
-  //무한 스크롤 트리거
-  useEffect(() => {
-    const [lastItem] = [...virtualizer.getVirtualItems()].reverse()
-
-    if (!lastItem) {
-      return
-    }
-
-    if (
-      lastItem.index >= contents.length - 1 &&
-      hasNextRecruitment &&
-      !isFetchingNextRecruitments
-    ) {
-      fetchNextRecruitments()
-    }
-
-    if (
-      lastItem.index >= contents.length - 1 &&
-      hasNextLecture &&
-      !isFetchingNextLectures
-    ) {
-      fetchNextLectures()
-    }
-  }, [
-    contents.length,
-    fetchNextLectures,
-    fetchNextRecruitments,
-    hasNextLecture,
-    hasNextRecruitment,
-    isFetchingNextLectures,
-    isFetchingNextRecruitments,
-    virtualizer,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    virtualizer.getVirtualItems(),
-  ])
 
   const windowWidth = useWindowWidth()
 
@@ -265,13 +252,17 @@ export default function BookmarkedContent({
 
                 if (
                   isLoaderRow &&
-                  (isFetchingNextLectures || isFetchingNextRecruitments)
+                  (hasNextRecruitment || hasNextLecture)
                 ) {
                   return (
                     <div
                       key={virtualRow.key}
                       data-index={virtualRow.index}
-                      ref={virtualizer.measureElement}
+                      ref={(node) => {
+                        // virtualizer 측정용 ref와 observer 타겟용 ref 모두 연결
+                        virtualizer.measureElement(node)
+                        if (node) observerRef.current = node
+                      }}
                     >
                       {[...Array(5)].map((_, i) => (
                         <div key={i} className="mb-2">

--- a/src/components/my-page/bookmarked-pages/BookmarkedLecture.tsx
+++ b/src/components/my-page/bookmarked-pages/BookmarkedLecture.tsx
@@ -9,7 +9,8 @@ import type {
 } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { SearchIcon } from 'lucide-react'
-import { useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
+import { useObserver } from '@/hooks'
 
 const ESTIMATE_CARD_SIZE_PX = 260
 
@@ -38,6 +39,19 @@ export default function BookmarkedLecture({
 
   //버추얼리스트 스크롤 대상
   const parentRef = useRef<HTMLDivElement>(null)
+
+  const handleIntersect = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+
+  // 무한 스크롤 옵저버 센서 부착용 훅
+  const observerRef = useObserver(handleIntersect, {
+    threshold: 0,
+    root: parentRef.current,
+  })
+
   //가상화 인스턴스
   const virtualizer = useVirtualizer({
     count: hasNextPage ? lectures.length + 1 : lectures.length,
@@ -45,31 +59,6 @@ export default function BookmarkedLecture({
     estimateSize: () => ESTIMATE_CARD_SIZE_PX,
     overscan: 5,
   })
-
-  //무한 스크롤 트리거
-  useEffect(() => {
-    const [lastItem] = [...virtualizer.getVirtualItems()].reverse()
-
-    if (!lastItem) {
-      return
-    }
-
-    if (
-      lastItem.index >= lectures.length - 1 &&
-      hasNextPage &&
-      !isFetchingNextPage
-    ) {
-      fetchNextPage()
-    }
-  }, [
-    lectures.length,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    virtualizer,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    virtualizer.getVirtualItems(),
-  ])
 
   const items = virtualizer.getVirtualItems()
   return (
@@ -110,12 +99,16 @@ export default function BookmarkedLecture({
                 const isLoaderRow = virtualRow.index > lectures.length - 1
                 const lecture = lectures[virtualRow.index]
 
-                if (isLoaderRow && isFetchingNextPage) {
+                if (isLoaderRow && hasNextPage) {
                   return (
                     <div
                       key={virtualRow.key}
                       data-index={virtualRow.index}
-                      ref={virtualizer.measureElement}
+                      ref={(node) => {
+                        // virtualizer 측정용 ref와 observer 타겟용 ref 모두 연결
+                        virtualizer.measureElement(node)
+                        if (node) observerRef.current = node
+                      }}
                     >
                       {[...Array(5)].map((_, i) => (
                         <div key={i} className="mb-2">

--- a/src/components/my-page/bookmarked-pages/BookmarkedLecture.tsx
+++ b/src/components/my-page/bookmarked-pages/BookmarkedLecture.tsx
@@ -2,9 +2,7 @@ import { ListItemSkeleton } from '@/components'
 import { Input } from '@/components/common/input'
 import EmptyResultState from '@/components/common/state/EmptyResultState'
 import BookmarkedLectureCard from '@/components/my-page/bookmarked-lecture/BookmarkedLectureCard'
-import { useWindowHeight } from '@/hooks'
 import type { BookmarkedLectures } from '@/types/api-response-types/lecture-response-type'
-import { cn } from '@/utils'
 import type {
   InfiniteData,
   UseInfiniteQueryResult,
@@ -14,8 +12,7 @@ import { SearchIcon } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 
 const ESTIMATE_CARD_SIZE_PX = 260
-const OVER_SCAN = 3
-const FOOTER_SPACE = 500 //완벽히 footer 사이즈에 맞춘게 아니고 적당히 보이게 설정
+
 
 interface BookmarkedLectureProps {
   bookmarkedLecturesInfiniteQueryResult: UseInfiniteQueryResult<
@@ -35,7 +32,7 @@ export default function BookmarkedLecture({
   const { data, isFetchingNextPage, fetchNextPage, hasNextPage } =
     bookmarkedLecturesInfiniteQueryResult
 
-  const windowHeight = useWindowHeight()
+
 
   const lectures = data ? data.pages.flatMap((page) => page.results) : []
 
@@ -46,7 +43,7 @@ export default function BookmarkedLecture({
     count: hasNextPage ? lectures.length + 1 : lectures.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => ESTIMATE_CARD_SIZE_PX,
-    overscan: OVER_SCAN,
+    overscan: 5,
   })
 
   //무한 스크롤 트리거
@@ -76,7 +73,7 @@ export default function BookmarkedLecture({
 
   const items = virtualizer.getVirtualItems()
   return (
-    <div>
+    <div className="flex h-full flex-col max-h-[1500px]">
       <header className="mb-6 flex flex-col items-center justify-between gap-2 lg:flex-row">
         <div className="flex w-full flex-col gap-2 lg:w-auto">
           <h1 className="text-heading3 text-gray-900">북마크한 강의</h1>
@@ -94,16 +91,10 @@ export default function BookmarkedLecture({
           />
         </div>
       </header>
-      <main
-        className="overflow-y-auto"
-        ref={parentRef}
-        style={{ height: `${windowHeight - FOOTER_SPACE}px` }}
-      >
+      <main className="flex-1 overflow-y-auto " ref={parentRef}>
         <div
-          className={cn(
-            `h-[${virtualizer.getTotalSize()}px]`,
-            'relative w-full'
-          )}
+          className="relative w-full"
+          style={{ height: `${virtualizer.getTotalSize()}px` }}
         >
           <div
             style={{

--- a/src/components/my-page/bookmarked-pages/BookmarkedRecruitment.tsx
+++ b/src/components/my-page/bookmarked-pages/BookmarkedRecruitment.tsx
@@ -10,12 +10,11 @@ import type { BookmarkedRecruitments } from '@/types/api-response-types/recruitm
 import { useEffect, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { cn } from '@/utils'
-import { useWindowHeight } from '@/hooks'
 import EmptyResultState from '@/components/common/state/EmptyResultState'
 
 const ESTIMATE_CARD_SIZE_PX = 260
 const OVER_SCAN = 3
-const FOOTER_SPACE = 500 //완벽히 footer 사이즈에 맞춘게 아니고 적당히 보이게 설정
+
 
 interface BookmarkedRecruitmentProps {
   bookmarkedRecruitmentInfinteQueryResult: UseInfiniteQueryResult<
@@ -34,7 +33,7 @@ export default function BookmarkedRecruitment({
   const { data, isFetchingNextPage, fetchNextPage, hasNextPage } =
     bookmarkedRecruitmentInfinteQueryResult
 
-  const windowHeight = useWindowHeight()
+
 
   const recruitments = data ? data.pages.flatMap((page) => page.results) : []
 
@@ -75,8 +74,8 @@ export default function BookmarkedRecruitment({
 
   const items = virtualizer.getVirtualItems()
   return (
-    <div>
-      <header className="mb-6 flex w-full flex-col items-center justify-between gap-2 lg:flex-row">
+    <div className="flex h-full flex-col max-h-[1500px]">
+      <header className="mb-6 flex w-full flex-shrink-0 flex-col items-center justify-between gap-2 lg:flex-row">
         <div className="flex w-full flex-col items-start justify-center gap-2 lg:w-auto">
           <h1 className="text-heading3 text-gray-900">북마크한 공고</h1>
           <span className="text-gray-600">
@@ -94,16 +93,10 @@ export default function BookmarkedRecruitment({
           />
         </div>
       </header>
-      <main
-        className="overflow-y-auto"
-        ref={parentRef}
-        style={{ height: `${windowHeight - FOOTER_SPACE}px` }}
-      >
+      <main className="flex-1 overflow-y-auto" ref={parentRef}>
         <div
-          className={cn(
-            `h-[${virtualizer.getTotalSize()}px]`,
-            'relative w-full'
-          )}
+          className="relative w-full"
+          style={{ height: `${virtualizer.getTotalSize()}px` }}
         >
           <div
             style={{

--- a/src/components/my-page/bookmarked-pages/BookmarkedRecruitment.tsx
+++ b/src/components/my-page/bookmarked-pages/BookmarkedRecruitment.tsx
@@ -7,10 +7,10 @@ import type {
   UseInfiniteQueryResult,
 } from '@tanstack/react-query'
 import type { BookmarkedRecruitments } from '@/types/api-response-types/recruitment-response-types'
-import { useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { cn } from '@/utils'
 import EmptyResultState from '@/components/common/state/EmptyResultState'
+import { useObserver } from '@/hooks'
 
 const ESTIMATE_CARD_SIZE_PX = 260
 const OVER_SCAN = 3
@@ -39,6 +39,19 @@ export default function BookmarkedRecruitment({
 
   //버추얼리스트 스크롤 대상
   const parentRef = useRef<HTMLDivElement>(null)
+  
+  const handleIntersect = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+
+  // 무한 스크롤 옵저버 센서 부착용 훅
+  const observerRef = useObserver(handleIntersect, {
+    threshold: 0,
+    root: parentRef.current,
+  })
+
   //가상화 인스턴스
   const virtualizer = useVirtualizer({
     count: hasNextPage ? recruitments.length + 1 : recruitments.length,
@@ -46,31 +59,6 @@ export default function BookmarkedRecruitment({
     estimateSize: () => ESTIMATE_CARD_SIZE_PX,
     overscan: OVER_SCAN,
   })
-
-  //무한 스크롤 트리거
-  useEffect(() => {
-    const [lastItem] = [...virtualizer.getVirtualItems()].reverse()
-
-    if (!lastItem) {
-      return
-    }
-
-    if (
-      lastItem.index >= recruitments.length - 1 &&
-      hasNextPage &&
-      !isFetchingNextPage
-    ) {
-      fetchNextPage()
-    }
-  }, [
-    recruitments.length,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    virtualizer,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    virtualizer.getVirtualItems(),
-  ])
 
   const items = virtualizer.getVirtualItems()
   return (
@@ -112,12 +100,16 @@ export default function BookmarkedRecruitment({
                 const isLoaderRow = virtualRow.index > recruitments.length - 1
                 const recruitment = recruitments[virtualRow.index]
 
-                if (isLoaderRow && isFetchingNextPage) {
+                if (isLoaderRow && hasNextPage) {
                   return (
                     <div
                       key={virtualRow.key}
                       data-index={virtualRow.index}
-                      ref={virtualizer.measureElement}
+                      ref={(node) => {
+                        // virtualizer 측정용 ref와 observer 타겟용 ref 모두 연결
+                        virtualizer.measureElement(node)
+                        if (node) observerRef.current = node
+                      }}
                     >
                       {[...Array(5)].map((_, i) => (
                         <div key={i} className="mb-2">


### PR DESCRIPTION
## 🚀 PR 요약

> 무한 스크롤 구동 시 발생하는 API 연속 호출(무한 루프) 및 초기 스크롤바 부재 시 Fetching 불가 버그를 IntersectionObserver 패턴으로 리팩토링하여 해결

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [x] refactor: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- **[BookmarkedContent](cci:1://file:///Users/ljh/Programming/oz-externship-clone/src/components/my-page/bookmarked-pages/BookmarkedContent.tsx:47:0-318:1), [BookmarkedRecruitment](cci:1://file:///Users/ljh/Programming/oz-externship-clone/src/components/my-page/bookmarked-pages/BookmarkedRecruitment.tsx:27:0-150:1), [BookmarkedLecture](cci:1://file:///Users/ljh/Programming/oz-externship-clone/src/components/my-page/bookmarked-pages/BookmarkedLecture.tsx:27:0-149:1) 3가지 컴포넌트 무한 스크롤 로직 Refactoring**
  - 기존의 `@tanstack/react-virtual`이 제공하는 `scrollOffset`이나 가상 아이템 인덱스 값을 직접 계산하여 Fetching 하던 하드코딩 로직 삭제.
  - 이를 대체하여 가장 하단에 위치한 로딩 스켈레톤(Loader 뼈대 요소)에 기존에 구현되어 있던 [useObserver](cci:1://file:///Users/ljh/Programming/oz-externship-clone/src/hooks/useObserver.ts:2:0-31:1) 훅을 부착하는 교차 감지(IntersectionObserver) 표준 패턴으로 전면 변경.
- **API 폭주(Infinite Loop) 버그 해결**
  - 뷰포트 크기와 무관하게 과도한 Overscan 설정으로 인해 데이터 로딩 즉시 다음 페이지가 연달아 호출되던 무한 루프 버그 원천 차단.
- **소량 데이터 시나리오(스크롤바 부재) 버그 해결**
  - 초기 데이터가 화면을 다 채우지 못해 컨테이너에 스크롤 박스가 생기지 않을 경우, `scrollOffset`이 `0`에 고정되어 다음 페이지 Fetching이 아예 발동하지 않던 치명적 버그 수정 완료 (교차 감지 방식으로 자동 해결됨).



## 🔗 연관된 이슈

> closes #10
